### PR TITLE
chore: GHA workflow to publish npm package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,28 @@
+name: Publish NPM Package
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: publish
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm
+        run: npm install -g npm@latest
+      
+      - name: Publish
+        run: npm publish --access public


### PR DESCRIPTION
The new workflow enables `npm publish` to be triggered on push to main branch by OIDC.
reference: https://github.com/smartcontractkit/test_npm_trusted_publishers/blob/main/.github/workflows/release.yaml