### PR TITLE
gas: optimize Solidity loop increments

### DIFF
--- a/packages/cross-chain-identity/src/CredentialRegistry.sol
+++ b/packages/cross-chain-identity/src/CredentialRegistry.sol
@@ -82,7 +82,7 @@ contract CredentialRegistry is PolicyProtectedUpgradeable, ICredentialRegistry {
     if (expiresAt > 0 && expiresAt <= block.timestamp) {
       revert InvalidCredentialConfiguration("Invalid expiration time");
     }
-    for (uint256 i = 0; i < credentialTypeIds.length; i++) {
+    for (uint256 i; i < credentialTypeIds.length; ++i) {
       _registerCredential(ccid, credentialTypeIds[i], expiresAt, credentialDatas[i]);
     }
   }
@@ -99,7 +99,7 @@ contract CredentialRegistry is PolicyProtectedUpgradeable, ICredentialRegistry {
     runPolicyWithContext(context)
   {
     uint256 length = _credentialRegistryStorage().credentialTypeIdsByCCID[ccid].length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       if (_credentialRegistryStorage().credentialTypeIdsByCCID[ccid][i] == credentialTypeId) {
         _credentialRegistryStorage().credentialTypeIdsByCCID[ccid][i] =
           _credentialRegistryStorage().credentialTypeIdsByCCID[ccid][length - 1];
@@ -129,7 +129,7 @@ contract CredentialRegistry is PolicyProtectedUpgradeable, ICredentialRegistry {
       revert InvalidCredentialConfiguration("Invalid expiration time");
     }
     uint256 length = _credentialRegistryStorage().credentialTypeIdsByCCID[ccid].length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       if (_credentialRegistryStorage().credentialTypeIdsByCCID[ccid][i] == credentialTypeId) {
         uint40 currentExpiresAt = _credentialRegistryStorage().credentials[ccid][credentialTypeId].expiresAt;
 
@@ -153,7 +153,7 @@ contract CredentialRegistry is PolicyProtectedUpgradeable, ICredentialRegistry {
 
   /// @inheritdoc ICredentialRegistry
   function getCredential(bytes32 ccid, bytes32 credentialTypeId) public view returns (Credential memory) {
-    for (uint256 i = 0; i < _credentialRegistryStorage().credentialTypeIdsByCCID[ccid].length; i++) {
+    for (uint256 i; i < _credentialRegistryStorage().credentialTypeIdsByCCID[ccid].length; ++i) {
       if (_credentialRegistryStorage().credentialTypeIdsByCCID[ccid][i] == credentialTypeId) {
         return _credentialRegistryStorage().credentials[ccid][credentialTypeId];
       }
@@ -172,7 +172,7 @@ contract CredentialRegistry is PolicyProtectedUpgradeable, ICredentialRegistry {
   {
     uint256 length = credentialTypeIds.length;
     Credential[] memory credentials = new Credential[](length);
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       credentials[i] = getCredential(ccid, credentialTypeIds[i]);
     }
     return credentials;
@@ -205,7 +205,7 @@ contract CredentialRegistry is PolicyProtectedUpgradeable, ICredentialRegistry {
     override
     returns (bool)
   {
-    for (uint256 i = 0; i < credentialTypeIds.length; i++) {
+    for (uint256 i; i < credentialTypeIds.length; ++i) {
       if (!_validate(ccid, credentialTypeIds[i], context)) {
         return false;
       }
@@ -215,7 +215,7 @@ contract CredentialRegistry is PolicyProtectedUpgradeable, ICredentialRegistry {
 
   function _validate(bytes32 ccid, bytes32 credentialTypeId, bytes calldata /*context*/ ) internal view returns (bool) {
     uint256 length = _credentialRegistryStorage().credentialTypeIdsByCCID[ccid].length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       if (_credentialRegistryStorage().credentialTypeIdsByCCID[ccid][i] == credentialTypeId) {
         return (
           _credentialRegistryStorage().credentials[ccid][credentialTypeId].expiresAt == 0
@@ -235,7 +235,7 @@ contract CredentialRegistry is PolicyProtectedUpgradeable, ICredentialRegistry {
     internal
   {
     uint256 length = _credentialRegistryStorage().credentialTypeIdsByCCID[ccid].length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       if (_credentialRegistryStorage().credentialTypeIdsByCCID[ccid][i] == credentialTypeId) {
         revert CredentialAlreadyRegistered(ccid, credentialTypeId);
       }

--- a/packages/cross-chain-identity/src/CredentialRegistryIdentityValidator.sol
+++ b/packages/cross-chain-identity/src/CredentialRegistryIdentityValidator.sol
@@ -77,11 +77,11 @@ contract CredentialRegistryIdentityValidator is OwnableUpgradeable, ICredentialR
     onlyInitializing
   {
     uint256 length = credentialSourceInputs.length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       _addCredentialSource(credentialSourceInputs[i]);
     }
     length = credentialRequirementInputs.length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       _addCredentialRequirement(credentialRequirementInputs[i]);
     }
   }
@@ -96,7 +96,7 @@ contract CredentialRegistryIdentityValidator is OwnableUpgradeable, ICredentialR
       revert InvalidRequirementConfiguration("Max requirements reached");
     }
     bytes32 requirementId = input.requirementId;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       if (_credentialRegistryIdentityValidatorStorage().requirements[i] == requirementId) {
         revert RequirementExists(requirementId);
       }
@@ -121,7 +121,7 @@ contract CredentialRegistryIdentityValidator is OwnableUpgradeable, ICredentialR
   /// @inheritdoc ICredentialRequirements
   function removeCredentialRequirement(bytes32 requirementId) public virtual override onlyOwner {
     uint256 length = _credentialRegistryIdentityValidatorStorage().requirements.length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       if (_credentialRegistryIdentityValidatorStorage().requirements[i] == requirementId) {
         _credentialRegistryIdentityValidatorStorage().requirements[i] =
           _credentialRegistryIdentityValidatorStorage().requirements[length - 1];
@@ -165,7 +165,7 @@ contract CredentialRegistryIdentityValidator is OwnableUpgradeable, ICredentialR
     if (length >= MAX_REQUIREMENT_SOURCES) {
       revert InvalidRequirementConfiguration("Max credential sources reached for credential type");
     }
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       // Load the entire source struct into memory once
       CredentialSource memory existingSource =
         _credentialRegistryIdentityValidatorStorage().credentialSources[credentialTypeId][i];
@@ -201,7 +201,7 @@ contract CredentialRegistryIdentityValidator is OwnableUpgradeable, ICredentialR
   {
     bytes32 sourceId = keccak256(abi.encodePacked(identityRegistry, credentialRegistry));
     uint256 length = _credentialRegistryIdentityValidatorStorage().credentialSources[credentialTypeId].length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       // Load the entire source struct into memory once
       CredentialSource memory existingSource =
         _credentialRegistryIdentityValidatorStorage().credentialSources[credentialTypeId][i];
@@ -229,7 +229,7 @@ contract CredentialRegistryIdentityValidator is OwnableUpgradeable, ICredentialR
   /// @inheritdoc IIdentityValidator
   function validate(address account, bytes calldata context) public view virtual override returns (bool) {
     uint256 length = _credentialRegistryIdentityValidatorStorage().requirements.length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       if (!_validateRequirement(account, _credentialRegistryIdentityValidatorStorage().requirements[i], context)) {
         return false;
       }
@@ -250,7 +250,7 @@ contract CredentialRegistryIdentityValidator is OwnableUpgradeable, ICredentialR
     CredentialRequirement memory requirement =
       _credentialRegistryIdentityValidatorStorage().credentialRequirementMap[requirementId];
     uint256 validations = 0;
-    for (uint256 i = 0; i < requirement.credentialTypeIds.length; i++) {
+    for (uint256 i; i < requirement.credentialTypeIds.length; ++i) {
       validations = _validateCredential(
         account, requirement.credentialTypeIds[i], validations, requirement.minValidations, requirement.invert, context
       );
@@ -276,7 +276,7 @@ contract CredentialRegistryIdentityValidator is OwnableUpgradeable, ICredentialR
   {
     uint256 validations = currentValidations;
     uint256 length = _credentialRegistryIdentityValidatorStorage().credentialSources[credentialTypeId].length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       CredentialSource memory source =
         _credentialRegistryIdentityValidatorStorage().credentialSources[credentialTypeId][i];
       bytes32 ccid = IIdentityRegistry(source.identityRegistry).getIdentity(account);

--- a/packages/cross-chain-identity/src/CredentialRegistryIdentityValidatorPolicy.sol
+++ b/packages/cross-chain-identity/src/CredentialRegistryIdentityValidatorPolicy.sol
@@ -59,7 +59,7 @@ contract CredentialRegistryIdentityValidatorPolicy is Policy, CredentialRegistry
       revert InvalidParameters("expected at least 1 parameter");
     }
 
-    for (uint256 i = 0; i < parameters.length; i++) {
+    for (uint256 i; i < parameters.length; ++i) {
       address account = abi.decode(parameters[i], (address));
       if (!validate(account, context)) {
         revert IPolicyEngine.PolicyRejected("account identity validation failed");

--- a/packages/cross-chain-identity/src/IdentityRegistry.sol
+++ b/packages/cross-chain-identity/src/IdentityRegistry.sol
@@ -73,7 +73,7 @@ contract IdentityRegistry is PolicyProtectedUpgradeable, IIdentityRegistry {
     if (ccids.length == 0 || ccids.length != accounts.length) {
       revert InvalidIdentityConfiguration("Invalid input length");
     }
-    for (uint256 i = 0; i < ccids.length; i++) {
+    for (uint256 i; i < ccids.length; ++i) {
       _registerIdentity(ccids[i], accounts[i], context);
     }
   }

--- a/packages/cross-chain-identity/src/TrustedIssuerRegistry.sol
+++ b/packages/cross-chain-identity/src/TrustedIssuerRegistry.sol
@@ -112,7 +112,7 @@ contract TrustedIssuerRegistry is PolicyProtectedUpgradeable, ITrustedIssuerRegi
     $.trustedIssuers[issuerIdHash] = false;
 
     uint256 length = $.issuerList.length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       if ($.issuerList[i] == issuerIdHash) {
         $.issuerList[i] = $.issuerList[length - 1];
         $.issuerList.pop();

--- a/packages/policy-management/src/core/PolicyEngine.sol
+++ b/packages/policy-management/src/core/PolicyEngine.sol
@@ -129,7 +129,7 @@ contract PolicyEngine is Initializable, AccessControlUpgradeable, IPolicyEngine 
     }
 
     IPolicyEngine.Parameter[] memory extractedParameters = _extractParameters(payload);
-    for (uint256 i = 0; i < policies.length; i++) {
+    for (uint256 i; i < policies.length; ++i) {
       address policy = policies[i];
 
       bytes[] memory policyParameterValues = _policyParameterValues(
@@ -161,7 +161,7 @@ contract PolicyEngine is Initializable, AccessControlUpgradeable, IPolicyEngine 
       return;
     }
 
-    for (uint256 i = 0; i < policies.length; i++) {
+    for (uint256 i; i < policies.length; ++i) {
       address policy = policies[i];
 
       bytes[] memory policyParameterValues = _policyParameterValues(
@@ -198,7 +198,7 @@ contract PolicyEngine is Initializable, AccessControlUpgradeable, IPolicyEngine 
 
   /// @inheritdoc IPolicyEngine
   function setExtractors(bytes4[] calldata selectors, address extractor) public virtual override onlyRole(ADMIN_ROLE) {
-    for (uint256 i = 0; i < selectors.length; i++) {
+    for (uint256 i; i < selectors.length; ++i) {
       _setExtractor(selectors[i], extractor);
     }
   }
@@ -266,7 +266,7 @@ contract PolicyEngine is Initializable, AccessControlUpgradeable, IPolicyEngine 
   function removePolicy(address target, bytes4 selector, address policy) public virtual override onlyRole(ADMIN_ROLE) {
     address[] storage policies = _policyEngineStorage().targetPolicies[target][selector];
     address removedPolicy = address(0);
-    for (uint256 i = 0; i < policies.length; i++) {
+    for (uint256 i; i < policies.length; ++i) {
       if (policies[i] == policy) {
         removedPolicy = policies[i];
         for (uint256 j = i; j < policies.length - 1; j++) {
@@ -352,7 +352,7 @@ contract PolicyEngine is Initializable, AccessControlUpgradeable, IPolicyEngine 
       revert Policy.InvalidParameters("Maximum policies reached");
     }
     address[] memory policies = _policyEngineStorage().targetPolicies[target][selector];
-    for (uint256 i = 0; i < policies.length; i++) {
+    for (uint256 i; i < policies.length; ++i) {
       if (policies[i] == policy) {
         revert Policy.InvalidParameters("Policy already added");
       }
@@ -408,8 +408,8 @@ contract PolicyEngine is Initializable, AccessControlUpgradeable, IPolicyEngine 
     }
 
     uint256 mappedParameterCount = 0;
-    for (uint256 i = 0; i < extractedParameters.length; i++) {
-      for (uint256 j = 0; j < parameterCount; j++) {
+    for (uint256 i; i < extractedParameters.length; ++i) {
+      for (uint256 j; j < parameterCount; ++j) {
         if (extractedParameters[i].name == policyParameterNames[j]) {
           policyParameterValues[j] = extractedParameters[i].value;
           mappedParameterCount++;
@@ -430,7 +430,7 @@ contract PolicyEngine is Initializable, AccessControlUpgradeable, IPolicyEngine 
     }
     bytes4 selector = bytes4(err);
     bytes memory errorData = new bytes(err.length - 4);
-    for (uint256 i = 0; i < err.length - 4; i++) {
+    for (uint256 i; i < err.length - 4; ++i) {
       errorData[i] = err[i + 4];
     }
     return (selector, errorData);

--- a/packages/policy-management/src/libraries/CertifiedActionLib.sol
+++ b/packages/policy-management/src/libraries/CertifiedActionLib.sol
@@ -39,7 +39,7 @@ library CertifiedActionLib {
     // keccak256( keccak256(encodeData(value[0])) ‖ keccak256(encodeData(value[1])) ‖ … ‖
     //            keccak256(encodeData(value[n])) )
     bytes32[] memory hashes = new bytes32[](parameters.length);
-    for (uint256 i = 0; i < parameters.length; i++) {
+    for (uint256 i; i < parameters.length; ++i) {
       hashes[i] = keccak256(parameters[i]);
     }
     return keccak256(abi.encodePacked(hashes));

--- a/packages/policy-management/src/policies/AllowPolicy.sol
+++ b/packages/policy-management/src/policies/AllowPolicy.sol
@@ -98,7 +98,7 @@ contract AllowPolicy is Policy {
     // Gas optimization: Load storage reference once instead of calling _getAllowPolicyStorage() in each iteration
     AllowPolicyStorage storage $ = _getAllowPolicyStorage();
 
-    for (uint256 i = 0; i < parameters.length; i++) {
+    for (uint256 i; i < parameters.length; ++i) {
       address account = abi.decode(parameters[i], (address));
       if (!$.allowList[account]) {
         revert IPolicyEngine.PolicyRejected("address is not on allow list");

--- a/packages/policy-management/src/policies/BypassPolicy.sol
+++ b/packages/policy-management/src/policies/BypassPolicy.sol
@@ -97,7 +97,7 @@ contract BypassPolicy is Policy {
     }
     // Gas optimization: load storage reference once
     BypassPolicyStorage storage $ = _getBypassPolicyStorage();
-    for (uint256 i = 0; i < parameters.length; i++) {
+    for (uint256 i; i < parameters.length; ++i) {
       address account = abi.decode(parameters[i], (address));
       if (!$.allowList[account]) {
         return IPolicyEngine.PolicyResult.Continue;

--- a/packages/policy-management/src/policies/RejectPolicy.sol
+++ b/packages/policy-management/src/policies/RejectPolicy.sol
@@ -96,7 +96,7 @@ contract RejectPolicy is Policy {
     }
     // Gas optimization: load storage reference once
     RejectPolicyStorage storage $ = _getRejectPolicyStorage();
-    for (uint256 i = 0; i < parameters.length; i++) {
+    for (uint256 i; i < parameters.length; ++i) {
       address account = abi.decode(parameters[i], (address));
       if ($.rejectList[account]) {
         revert IPolicyEngine.PolicyRejected("address is on reject list");

--- a/packages/policy-management/src/policies/RoleBasedAccessControlPolicy.sol
+++ b/packages/policy-management/src/policies/RoleBasedAccessControlPolicy.sol
@@ -78,7 +78,7 @@ contract RoleBasedAccessControlPolicy is Policy, AccessControlUpgradeable {
   function grantOperationAllowanceToRole(bytes4 operation, bytes32 role) public onlyOwner {
     RoleBasedAccessControlPolicyStorage storage $ = _getRoleBasedAccessControlPolicyStorage();
     uint256 length = $.rolesByOperation[operation].length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       if ($.rolesByOperation[operation][i] == role) {
         revert("Role already has operation allowance");
       }
@@ -96,7 +96,7 @@ contract RoleBasedAccessControlPolicy is Policy, AccessControlUpgradeable {
   function removeOperationAllowanceFromRole(bytes4 operation, bytes32 role) public onlyOwner {
     RoleBasedAccessControlPolicyStorage storage $ = _getRoleBasedAccessControlPolicyStorage();
     uint256 length = $.rolesByOperation[operation].length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       if ($.rolesByOperation[operation][i] == role) {
         $.rolesByOperation[operation][i] = $.rolesByOperation[operation][length - 1];
         $.rolesByOperation[operation].pop();
@@ -118,7 +118,7 @@ contract RoleBasedAccessControlPolicy is Policy, AccessControlUpgradeable {
     RoleBasedAccessControlPolicyStorage storage $ = _getRoleBasedAccessControlPolicyStorage();
     bytes32[] memory roles = $.rolesByOperation[operation];
     uint256 length = roles.length;
-    for (uint256 i = 0; i < length; i++) {
+    for (uint256 i; i < length; ++i) {
       if (hasRole(roles[i], account)) {
         return true;
       }

--- a/packages/tokens/erc-3643/src/ComplianceTokenERC3643.sol
+++ b/packages/tokens/erc-3643/src/ComplianceTokenERC3643.sol
@@ -174,7 +174,7 @@ contract ComplianceTokenERC3643 is Initializable, PolicyProtectedUpgradeable, Co
    */
   function batchTransfer(address[] calldata _toList, uint256[] calldata _amounts) external override {
     if (_toList.length != _amounts.length) revert LengthMismatch();
-    for (uint256 i = 0; i < _toList.length; i++) {
+    for (uint256 i; i < _toList.length; ++i) {
       transfer(_toList[i], _amounts[i]);
     }
   }
@@ -222,7 +222,7 @@ contract ComplianceTokenERC3643 is Initializable, PolicyProtectedUpgradeable, Co
     override
   {
     if (_fromList.length != _toList.length || _toList.length != _amounts.length) revert LengthMismatch();
-    for (uint256 i = 0; i < _fromList.length; i++) {
+    for (uint256 i; i < _fromList.length; ++i) {
       forcedTransfer(_fromList[i], _toList[i], _amounts[i]);
     }
   }
@@ -232,7 +232,7 @@ contract ComplianceTokenERC3643 is Initializable, PolicyProtectedUpgradeable, Co
    */
   function batchMint(address[] calldata _toList, uint256[] calldata _amounts) external override {
     if (_toList.length != _amounts.length) revert LengthMismatch();
-    for (uint256 i = 0; i < _toList.length; i++) {
+    for (uint256 i; i < _toList.length; ++i) {
       mint(_toList[i], _amounts[i]);
     }
   }
@@ -242,7 +242,7 @@ contract ComplianceTokenERC3643 is Initializable, PolicyProtectedUpgradeable, Co
    */
   function batchBurn(address[] calldata _userAddresses, uint256[] calldata _amounts) external override {
     if (_userAddresses.length != _amounts.length) revert LengthMismatch();
-    for (uint256 i = 0; i < _userAddresses.length; i++) {
+    for (uint256 i; i < _userAddresses.length; ++i) {
       burn(_userAddresses[i], _amounts[i]);
     }
   }
@@ -252,7 +252,7 @@ contract ComplianceTokenERC3643 is Initializable, PolicyProtectedUpgradeable, Co
    */
   function batchSetAddressFrozen(address[] calldata _userAddresses, bool[] calldata _freeze) external override {
     if (_userAddresses.length != _freeze.length) revert LengthMismatch();
-    for (uint256 i = 0; i < _userAddresses.length; i++) {
+    for (uint256 i; i < _userAddresses.length; ++i) {
       setAddressFrozen(_userAddresses[i], _freeze[i]);
     }
   }
@@ -262,7 +262,7 @@ contract ComplianceTokenERC3643 is Initializable, PolicyProtectedUpgradeable, Co
    */
   function batchFreezePartialTokens(address[] calldata _userAddresses, uint256[] calldata _amounts) external override {
     if (_userAddresses.length != _amounts.length) revert LengthMismatch();
-    for (uint256 i = 0; i < _userAddresses.length; i++) {
+    for (uint256 i; i < _userAddresses.length; ++i) {
       freezePartialTokens(_userAddresses[i], _amounts[i]);
     }
   }
@@ -272,7 +272,7 @@ contract ComplianceTokenERC3643 is Initializable, PolicyProtectedUpgradeable, Co
    */
   function batchUnfreezePartialTokens(address[] calldata _userAddresses, uint256[] calldata _amounts) external override {
     if (_userAddresses.length != _amounts.length) revert LengthMismatch();
-    for (uint256 i = 0; i < _userAddresses.length; i++) {
+    for (uint256 i; i < _userAddresses.length; ++i) {
       unfreezePartialTokens(_userAddresses[i], _amounts[i]);
     }
   }


### PR DESCRIPTION
## What
Optimizes production Solidity `for` loop increments by using default zero initialization and pre-increment.

## Why
`uint256` loop variables default to zero, so explicit `= 0` initialization is unnecessary. Pre-increment (`++i`) is also cheaper than post-increment (`i++`) because it does not need to preserve the previous value.

## Changes
- Updates production Solidity loops from `uint256 i = 0; ... i++` to `uint256 i; ... ++i`
- Applies the same pattern to nested loop counters where applicable
- Leaves tests, helpers, vendor files, and non-zero/decrement loops unchanged